### PR TITLE
add warning on improved mask and upscaling and make it disabled in settings by default

### DIFF
--- a/scripts/faceswaplab_settings/faceswaplab_settings.py
+++ b/scripts/faceswaplab_settings/faceswaplab_settings.py
@@ -201,7 +201,7 @@ def on_ui_settings() -> None:
     shared.opts.add_option(
         "faceswaplab_default_upscaled_swapper_improved_mask",
         shared.OptionInfo(
-            True,
+            False,
             "Default Use improved segmented mask (use pastenet to mask only the face) (requires restart)",
             gr.Checkbox,
             {"interactive": True},

--- a/scripts/faceswaplab_swapping/upscaled_inswapper.py
+++ b/scripts/faceswaplab_swapping/upscaled_inswapper.py
@@ -210,6 +210,11 @@ class UpscaledINSwapper(INSwapper):
                     )
 
                     if options.improved_mask:
+                        if k == 1:
+                            logger.warning(
+                                "Please note that improved mask does not work well without upscaling. Set upscaling to Lanczos at least if you want speed and want to use improved mask."
+                            )
+
                         logger.info("improved_mask")
                         mask = get_face_mask(aimg, bgr_fake)
                         bgr_fake = merge_images_with_mask(aimg, bgr_fake, mask)


### PR DESCRIPTION
Improved mask without upscaling in post-processing, produces artefacts. Don't use it without upscaling.


![00011-2320815419-swapped](https://github.com/glucauze/sd-webui-faceswaplab/assets/137925069/31e1bb7b-2286-4975-bbf0-72be24742aca)
