### PR TITLE
speed up ui, BREAKING : see changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.2.3
+
+Speed up ui : change the way default settings are manage by not storing them in ui-config.json
+
+Migration : YOU NEED TO recreate ui-config.json (delete) or at least remove any faceswaplab reference to be able to use default settings again.
+
+See this for explainations : https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6109
+
 # 1.2.2
 
 + Add NSFW filter option in settings (1 == disable)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FaceSwapLab for a1111/Vlad
 
+V1.2.3 : Breaking change for settings, please read changelog.
+
 Please read the documentation here : https://glucauze.github.io/sd-webui-faceswaplab/ 
 
 You can also read the [doc discussion section](https://github.com/glucauze/sd-webui-faceswaplab/discussions/categories/guide-doc)

--- a/scripts/faceswaplab.py
+++ b/scripts/faceswaplab.py
@@ -109,7 +109,13 @@ class FaceSwapScript(scripts.Script):
                 components += faceswaplab_unit_ui.faceswap_unit_ui(is_img2img, i)
             post_processing = faceswaplab_tab.postprocessing_ui()
         # If the order is modified, the before_process should be changed accordingly.
-        return components + post_processing
+
+        components = components + post_processing
+        # Ask sd to not store in ui-config.json
+        for component in components:
+            setattr(component, "do_not_save_to_config", True)
+
+        return components
 
     def read_config(
         self, p: StableDiffusionProcessing, *components: Tuple[Any, ...]

--- a/scripts/faceswaplab_globals.py
+++ b/scripts/faceswaplab_globals.py
@@ -16,7 +16,7 @@ REFERENCE_PATH = os.path.join(
 )
 
 # Defining the version flag for the application
-VERSION_FLAG: str = "v1.2.2"
+VERSION_FLAG: str = "v1.2.3"
 # Defining the path for 'sd-webui-faceswaplab' inside the 'extensions' directory
 EXTENSION_PATH = os.path.join("extensions", "sd-webui-faceswaplab")
 

--- a/scripts/faceswaplab_ui/faceswaplab_postprocessing_ui.py
+++ b/scripts/faceswaplab_ui/faceswaplab_postprocessing_ui.py
@@ -15,18 +15,19 @@ def postprocessing_ui() -> List[gr.components.Component]:
             face_restorer_name = gr.Radio(
                 label="Restore Face",
                 choices=["None"] + [x.name() for x in shared.face_restorers],
-                value=lambda: get_sd_option(
+                value=get_sd_option(
                     "faceswaplab_pp_default_face_restorer",
                     shared.face_restorers[0].name(),
                 ),
                 type="value",
                 elem_id="faceswaplab_pp_face_restorer",
             )
+
             with gr.Column():
                 face_restorer_visibility = gr.Slider(
                     0,
                     1,
-                    value=lambda: get_sd_option(
+                    value=get_sd_option(
                         "faceswaplab_pp_default_face_restorer_visibility", 1
                     ),
                     step=0.001,
@@ -36,7 +37,7 @@ def postprocessing_ui() -> List[gr.components.Component]:
                 codeformer_weight = gr.Slider(
                     0,
                     1,
-                    value=lambda: get_sd_option(
+                    value=get_sd_option(
                         "faceswaplab_pp_default_face_restorer_weight", 1
                     ),
                     step=0.001,
@@ -45,7 +46,7 @@ def postprocessing_ui() -> List[gr.components.Component]:
                 )
         upscaler_name = gr.Dropdown(
             choices=[upscaler.name for upscaler in shared.sd_upscalers],
-            value=lambda: get_sd_option("faceswaplab_pp_default_upscaler", "None"),
+            value=get_sd_option("faceswaplab_pp_default_upscaler", "None"),
             label="Upscaler",
             elem_id="faceswaplab_pp_upscaler",
         )
@@ -60,9 +61,7 @@ def postprocessing_ui() -> List[gr.components.Component]:
         upscaler_visibility = gr.Slider(
             0,
             1,
-            value=lambda: get_sd_option(
-                "faceswaplab_pp_default_upscaler_visibility", 1
-            ),
+            value=get_sd_option("faceswaplab_pp_default_upscaler_visibility", 1),
             step=0.1,
             label="Upscaler visibility (if scale = 1)",
             elem_id="faceswaplab_pp_upscaler_visibility",
@@ -123,7 +122,7 @@ def postprocessing_ui() -> List[gr.components.Component]:
                 label="sd model (experimental)",
                 elem_id="faceswaplab_pp_inpainting_sd_model",
             )
-    return [
+    components = [
         face_restorer_name,
         face_restorer_visibility,
         codeformer_weight,
@@ -138,3 +137,8 @@ def postprocessing_ui() -> List[gr.components.Component]:
         inpainting_sampler,
         inpaiting_model,
     ]
+
+    # Ask sd to not store in ui-config.json
+    for component in components:
+        setattr(component, "do_not_save_to_config", True)
+    return components

--- a/scripts/faceswaplab_ui/faceswaplab_unit_ui.py
+++ b/scripts/faceswaplab_ui/faceswaplab_unit_ui.py
@@ -17,7 +17,7 @@ def faceswap_unit_advanced_options(
             face_restorer_name = gr.Radio(
                 label="Restore Face",
                 choices=["None"] + [x.name() for x in shared.face_restorers],
-                value=lambda: get_sd_option(
+                value=get_sd_option(
                     "faceswaplab_default_upscaled_swapper_face_restorer",
                     "None",
                 ),
@@ -28,7 +28,7 @@ def faceswap_unit_advanced_options(
                 face_restorer_visibility = gr.Slider(
                     0,
                     1,
-                    value=lambda: get_sd_option(
+                    value=get_sd_option(
                         "faceswaplab_default_upscaled_swapper_face_restorer_visibility",
                         1.0,
                     ),
@@ -39,7 +39,7 @@ def faceswap_unit_advanced_options(
                 codeformer_weight = gr.Slider(
                     0,
                     1,
-                    value=lambda: get_sd_option(
+                    value=get_sd_option(
                         "faceswaplab_default_upscaled_swapper_face_restorer_weight", 1.0
                     ),
                     step=0.001,
@@ -48,33 +48,25 @@ def faceswap_unit_advanced_options(
                 )
         upscaler_name = gr.Dropdown(
             choices=[upscaler.name for upscaler in shared.sd_upscalers],
-            value=lambda: get_sd_option(
-                "faceswaplab_default_upscaled_swapper_upscaler", ""
-            ),
+            value=get_sd_option("faceswaplab_default_upscaled_swapper_upscaler", ""),
             label="Upscaler",
             elem_id=f"{id_prefix}_face{unit_num}_upscaler",
         )
 
         improved_mask = gr.Checkbox(
-            lambda: get_sd_option(
-                "faceswaplab_default_upscaled_swapper_improved_mask", False
-            ),
+            get_sd_option("faceswaplab_default_upscaled_swapper_improved_mask", False),
             interactive=True,
             label="Use improved segmented mask (use pastenet to mask only the face)",
             elem_id=f"{id_prefix}_face{unit_num}_improved_mask",
         )
         color_corrections = gr.Checkbox(
-            lambda: get_sd_option(
-                "faceswaplab_default_upscaled_swapper_fixcolor", False
-            ),
+            get_sd_option("faceswaplab_default_upscaled_swapper_fixcolor", False),
             interactive=True,
             label="Use color corrections",
             elem_id=f"{id_prefix}_face{unit_num}_color_corrections",
         )
         sharpen_face = gr.Checkbox(
-            lambda: get_sd_option(
-                "faceswaplab_default_upscaled_swapper_sharpen", False
-            ),
+            get_sd_option("faceswaplab_default_upscaled_swapper_sharpen", False),
             interactive=True,
             label="sharpen face",
             elem_id=f"{id_prefix}_face{unit_num}_sharpen_face",
@@ -82,7 +74,7 @@ def faceswap_unit_advanced_options(
         erosion_factor = gr.Slider(
             0.0,
             10.0,
-            lambda: get_sd_option("faceswaplab_default_upscaled_swapper_erosion", 1.0),
+            get_sd_option("faceswaplab_default_upscaled_swapper_erosion", 1.0),
             step=0.01,
             label="Upscaled swapper mask erosion factor, 1 = default behaviour.",
             elem_id=f"{id_prefix}_face{unit_num}_erosion_factor",
@@ -137,7 +129,7 @@ def faceswap_unit_ui(
                     elem_id=f"{id_prefix}_face{unit_num}_refresh_checkpoints",
                 )
 
-                def refresh_fn(selected: str) -> None:
+                def refresh_fn(selected: str):
                     return gr.Dropdown.update(
                         value=selected, choices=get_face_checkpoints()
                     )
@@ -288,6 +280,10 @@ Otherwise, read the [doc](https://glucauze.github.io/sd-webui-faceswaplab/doc/) 
         + options
         + post_inpainting
     )
+
+    # Ask sd to not store in ui-config.json
+    for component in gradio_components:
+        setattr(component, "do_not_save_to_config", True)
 
     # If changed, you need to change FaceSwapUnitSettings accordingly
     # ORDER of parameters is IMPORTANT. It should match the result of FaceSwapUnitSettings


### PR DESCRIPTION
Speed up ui : change the way default settings are manage by not storing them in ui-config.json

Migration : YOU NEED TO recreate ui-config.json (delete) or at least remove any faceswaplab reference to be able to use default settings again.

See this for explainations : https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6109
