### PR TITLE
remove override_settings in inpainting i2i_pp.py

### DIFF
--- a/scripts/faceswaplab_inpainting/i2i_pp.py
+++ b/scripts/faceswaplab_inpainting/i2i_pp.py
@@ -63,16 +63,18 @@ inpainting_steps : {options.inpainting_steps}
                     "prompt": prompt,
                     "negative_prompt": negative_prompt,
                     "denoising_strength": options.inpainting_denoising_strengh,
-                    "override_settings": {
-                        "return_mask_composite": False,
-                        "save_images_before_face_restoration": False,
-                        "save_images_before_highres_fix": False,
-                        "save_images_before_color_correction": False,
-                        "save_mask": False,
-                        "save_mask_composite": False,
-                        "samples_save": False,
-                    },
                 }
+                # Remove the following as they are not always supported on all platform :
+                # "override_settings": {
+                #     "return_mask_composite": False,
+                #     "save_images_before_face_restoration": False,
+                #     "save_images_before_highres_fix": False,
+                #     "save_images_before_color_correction": False,
+                #     "save_mask": False,
+                #     "save_mask_composite": False,
+                #     "samples_save": False,
+                # },
+
                 current_model_checkpoint = shared.opts.sd_model_checkpoint
                 if options.inpainting_model and options.inpainting_model != "Current":
                     # Change checkpoint


### PR DESCRIPTION
Remove override_settings in inpainting i2i_pp.py as they are not supported in some cases, i.e. sdnext for return_mask_composite and cause bugs

This will cause some masks to be saved if options in sd settings have been set which is not really a big deal.