### PR TITLE
fix crash albumentations==1.4.3

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,5 +1,6 @@
 cython
 ifnude
+albumentations==1.4.3
 insightface==0.7.3
 onnx>=1.14.0
 protobuf>=3.20.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 protobuf>=3.20.2
 cython
 ifnude
+albumentations==1.4.3
 insightface==0.7.3
 onnx>=1.14.0
 onnxruntime>=1.15.0


### PR DESCRIPTION
recent Upstream package changes causes installing insightface break webui
- for details read this post https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15564

fix solution, install `albumentations==1.4.3` before `insightface`
this way pip won't auto install  the newest version `1.4.4`

note I did not specifically test this with this extension this PR is based off knowledge